### PR TITLE
83 create reuseable modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,21 +1,63 @@
 import styles from "./Model.module.css";
-import { PropsWithChildren, ReactNode } from "react";
+import {
+  cloneElement,
+  PropsWithChildren,
+  ReactElement,
+  useContext,
+} from "react";
 import closeMenu from "/images/icon-close-modal.svg";
 import { createPortal } from "react-dom";
-
-interface ModalProps {
-  children: ReactNode;
-  closeModal: () => void;
+import { createContext } from "react";
+import { useState } from "react";
+interface WindowProps {
+  children: ReactElement;
+  name: string;
 }
 
-export default function Modal({ children, closeModal }: ModalProps) {
+interface ModalContextType {
+  openName: string;
+  open: (name: string) => void;
+  close: () => void;
+}
+
+const defaultValue: ModalContextType = {
+  openName: "",
+  open: () => {},
+  close: () => {},
+};
+
+//creating the Model context
+const ModalContext = createContext(defaultValue);
+
+export default function Modal({ children }: PropsWithChildren) {
+  const [openName, setOpenName] = useState("");
+  const close = () => setOpenName("");
+  const open = setOpenName;
+
+  return (
+    <ModalContext.Provider value={{ openName, close, open }}>
+      {children}
+    </ModalContext.Provider>
+  );
+}
+
+function Open({ children, opens: opensWindowName }) {
+  const { open } = useContext(ModalContext);
+  return cloneElement(children, { onClick: () => open(opensWindowName) });
+}
+
+function Window({ children, name }: WindowProps) {
+  const { openName, close } = useContext(ModalContext);
+
+  if (name !== openName) return null;
+
   return createPortal(
     <Overlay>
       <StyledModal>
-        <button onClick={closeModal} className={styles.closeMenuBtn}>
+        <button className={styles.closeMenuBtn}>
           <img src={closeMenu} alt="" />
         </button>
-        {children}
+        {cloneElement(children, { onCloseModal: close })}
       </StyledModal>
     </Overlay>,
     document.body
@@ -33,3 +75,6 @@ function Overlay({ children }: PropsWithChildren) {
     </div>
   );
 }
+
+Modal.Open = Open;
+Modal.Window = Window;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,35 @@
+import styles from "./Model.module.css";
+import { PropsWithChildren, ReactNode } from "react";
+import closeMenu from "/images/icon-close-modal.svg";
+import { createPortal } from "react-dom";
+
+interface ModalProps {
+  children: ReactNode;
+  closeModal: () => void;
+}
+
+export default function Modal({ children, closeModal }: ModalProps) {
+  return createPortal(
+    <Overlay>
+      <StyledModal>
+        <button onClick={closeModal} className={styles.closeMenuBtn}>
+          <img src={closeMenu} alt="" />
+        </button>
+        {children}
+      </StyledModal>
+    </Overlay>,
+    document.body
+  );
+}
+
+function StyledModal({ children }: PropsWithChildren) {
+  return <div className={styles.styledModal}>{children}</div>;
+}
+
+function Overlay({ children }: PropsWithChildren) {
+  return (
+    <div className={styles.overlay}>
+      <>{children}</>
+    </div>
+  );
+}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -41,7 +41,12 @@ export default function Modal({ children }: PropsWithChildren) {
   );
 }
 
-function Open({ children, opens: opensWindowName }) {
+interface OpenProps {
+  opens: string;
+  children: ReactElement;
+}
+
+function Open({ children, opens: opensWindowName }: OpenProps) {
   const { open } = useContext(ModalContext);
   return cloneElement(children, { onClick: () => open(opensWindowName) });
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -54,7 +54,7 @@ function Window({ children, name }: WindowProps) {
   return createPortal(
     <Overlay>
       <StyledModal>
-        <button className={styles.closeMenuBtn}>
+        <button onClick={close} className={styles.closeMenuBtn}>
           <img src={closeMenu} alt="" />
         </button>
         {cloneElement(children, { onCloseModal: close })}

--- a/src/components/Modal/Model.module.css
+++ b/src/components/Modal/Model.module.css
@@ -1,0 +1,33 @@
+.overlay {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(1px);
+}
+
+.styledModal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: var(--white);
+  border-radius: 10px;
+  padding: var(--spacing-400);
+  transition: all 0.5s;
+}
+
+.closeMenuBtn {
+  position: fixed;
+  right: 35px;
+  top: 35px;
+  text-decoration: none;
+  background-color: none;
+  border: none;
+  cursor: pointer;
+  background-color: var(--white);
+}

--- a/src/hooks/useOutsideClick.tsx
+++ b/src/hooks/useOutsideClick.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from "react";
+
+export function useOutsideClick(handler: () => void, listenCapturing = true) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    }
+
+    document.addEventListener("click", handleClick, listenCapturing);
+
+    return () => document.removeEventListener("click", handleClick);
+  }, [handler, listenCapturing]);
+
+  return ref;
+}

--- a/src/pages/Pots/AddPot/AddPot.tsx
+++ b/src/pages/Pots/AddPot/AddPot.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import Modal from "../../../components/Modal/Modal";
+
+export default function AddPot() {
+  const [modelState, setModalState] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setModalState(!modelState)}>+ Add Pot</button>
+      {modelState && (
+        <Modal
+          closeModal={() => {
+            setModalState(!modelState);
+            console.log(modelState);
+          }}
+        >
+          <h1>Add New Pot</h1>
+          <h2>{modelState}</h2>
+          <p>
+            Create a port to set savings targets. These can help keep you on
+            track as you save from special purchases
+          </p>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Pots/AddPot/AddPot.tsx
+++ b/src/pages/Pots/AddPot/AddPot.tsx
@@ -1,26 +1,42 @@
-import { useState } from "react";
 import Modal from "../../../components/Modal/Modal";
+import AddPotForm from "./Form";
 
 export default function AddPot() {
-  const [modelState, setModalState] = useState(false);
   return (
-    <div>
-      <button onClick={() => setModalState(!modelState)}>+ Add Pot</button>
-      {modelState && (
-        <Modal
-          closeModal={() => {
-            setModalState(!modelState);
-            console.log(modelState);
-          }}
-        >
-          <h1>Add New Pot</h1>
-          <h2>{modelState}</h2>
-          <p>
-            Create a port to set savings targets. These can help keep you on
-            track as you save from special purchases
-          </p>
-        </Modal>
-      )}
-    </div>
+    <Modal>
+      <Modal.Open opens="pot-form">
+        <button>+ Add Pot</button>
+      </Modal.Open>
+      <Modal.Window name="pot-form">
+        <AddPotForm />
+      </Modal.Window>
+    </Modal>
   );
+}
+
+{
+  /* // const [modelState, setModalState] = useState(false);
+  // return (
+  //   <div>
+  //     <button onClick={() => setModalState(!modelState)}>+ Add Pot</button>
+  //     {modelState && (
+  //       <Modal
+  //         closeModal={() => {
+  //           setModalState(!modelState);
+  //           console.log(modelState);
+  //         }}
+  //       >
+  //         <h1>Add New Pot</h1>
+  //         <h2>{modelState}</h2>
+  //         <p>
+  //           Create a port to set savings targets. These can help keep you on
+  //           track as you save from special purchases
+  //         </p>
+  //       </Modal>
+  //     )}
+  //   </div>
+  // ); */
+}
+{
+  /* } */
 }

--- a/src/pages/Pots/AddPot/Form.tsx
+++ b/src/pages/Pots/AddPot/Form.tsx
@@ -2,7 +2,11 @@ export default function AddPotForm({ onCloseModel }: any) {
   return (
     <form>
       <div>
-        <h1>this is the add pot from</h1>
+        <h1>Add New Pot</h1>
+        <p>
+          Create a port to set savings targets. These can help keep you on track
+          as you save from special purchases
+        </p>
       </div>
 
       <div>

--- a/src/pages/Pots/AddPot/Form.tsx
+++ b/src/pages/Pots/AddPot/Form.tsx
@@ -1,0 +1,13 @@
+export default function AddPotForm({ onCloseModel }: any) {
+  return (
+    <form>
+      <div>
+        <h1>this is the add pot from</h1>
+      </div>
+
+      <div>
+        <button onClick={onCloseModel}>close</button>
+      </div>
+    </form>
+  );
+}

--- a/src/pages/Pots/Pots.tsx
+++ b/src/pages/Pots/Pots.tsx
@@ -15,8 +15,6 @@ function calcPercentage(total: number, target: number) {
 export default function Pots() {
   const pots: Pot[] = useAppSelector((state) => state.pots.data);
 
-  console.log(pots[0]);
-
   return (
     <div className={styles.potsContainer}>
       <div className={styles.potsPageHeader}>
@@ -26,7 +24,7 @@ export default function Pots() {
 
       <div className={styles.potsCollection}>
         {pots.map((pot) => (
-          <div className={styles.potWrapper}>
+          <div key={pot.id} className={styles.potWrapper}>
             <div className={styles.menuBar}>
               <div className={styles.menuTitle}>
                 <div

--- a/src/pages/Pots/Pots.tsx
+++ b/src/pages/Pots/Pots.tsx
@@ -5,6 +5,7 @@ import PageHeader from "../sharedComponents/PageHeader/PageHeader";
 import PotOptionsButton from "./PotOptionsButton/PotOptionsButton";
 import utils from "../../helper/utils";
 import BeigeButton from "./BeigeButton/BeigeButton";
+import AddPot from "./AddPot/AddPot";
 
 function calcPercentage(total: number, target: number) {
   const percentage = (total / target) * 100;
@@ -20,7 +21,7 @@ export default function Pots() {
     <div className={styles.potsContainer}>
       <div className={styles.potsPageHeader}>
         <PageHeader title="Pots"></PageHeader>
-        <button>+Add New Pot</button>
+        <AddPot></AddPot>
       </div>
 
       <div className={styles.potsCollection}>

--- a/src/pages/Transactions/TransactionsPage.tsx
+++ b/src/pages/Transactions/TransactionsPage.tsx
@@ -1,3 +1,7 @@
 export default function Transactions() {
-  return <div>Transactions Page Coming Soon 🧑‍💻</div>;
+  return (
+    <div>
+      <h1>Transactions Page Coming Soon 🧑‍💻</h1>
+    </div>
+  );
 }


### PR DESCRIPTION
The reusable model has been created by using the compound component pattern and the ability to click outside of the modal has been taken out and been converted to a hook. 

Next task: 
- add new pot form 
- add pot to the backend via api